### PR TITLE
feat: Add toast notification for successful password update

### DIFF
--- a/src/components/profilesetting/password-settings.tsx
+++ b/src/components/profilesetting/password-settings.tsx
@@ -4,12 +4,14 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { ArrowLeft } from 'lucide-react';
 import { useState } from 'react';
+import { useToast } from '@/hooks/use-toast';
 
 interface PasswordSettingsProps {
   onCancel: () => void;
 }
 
 export default function PasswordSettings({ onCancel }: PasswordSettingsProps) {
+  const { toast } = useToast();
   const [isLoading, setIsLoading] = useState(false);
   const [currentPassword, setCurrentPassword] = useState('');
   const [newPassword, setNewPassword] = useState('');
@@ -56,7 +58,13 @@ export default function PasswordSettings({ onCancel }: PasswordSettingsProps) {
         throw new Error(data.error || 'Failed to update password');
       }
 
-      // Success
+      // Show success toast
+      toast({
+        title: "Password Updated",
+        description: "Your password has been changed successfully.",
+      });
+
+      // Close the dialog
       onCancel();
     } catch (err) {
       setError(err instanceof Error ? err.message : 'An error occurred');


### PR DESCRIPTION
fixed #82 
This pull request includes changes to the `PasswordSettings` component to provide user feedback upon successful password update. The most important changes include the addition of a toast notification to inform the user of the success.

Enhancements to user feedback:

* [`src/components/profilesetting/password-settings.tsx`](diffhunk://#diff-ddbc235fdcd32705b01dc63441f903c589652a3fd488e402732d06c8cf6b6e9cR7-R14): Added import for `useToast` hook and implemented a success toast notification when the password is updated successfully. [[1]](diffhunk://#diff-ddbc235fdcd32705b01dc63441f903c589652a3fd488e402732d06c8cf6b6e9cR7-R14) [[2]](diffhunk://#diff-ddbc235fdcd32705b01dc63441f903c589652a3fd488e402732d06c8cf6b6e9cL59-R67)